### PR TITLE
Add syntax highlighting to Clojure documentation codeblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add syntax highlighting to Clojure documentation codeblocks
+
 ## 2.4.5
 
 - Only log server communication when trace-level matches.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
         exclude("org.clojure", "core.async")
     }
     implementation ("com.rpl:proxy-plus:0.0.9")
-    implementation ("markdown-clj:markdown-clj:1.11.4")
+    implementation ("markdown-clj:markdown-clj:1.12.1")
 }
 
 sourceSets {

--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
         seesaw/seesaw {:mvn/version "1.5.0"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
         com.github.clojure-lsp/clojure-lsp {:mvn/version "2024.03.01-11.37.51"}
-        markdown-clj/markdown-clj {:mvn/version "1.11.4"}
+        markdown-clj/markdown-clj {:mvn/version "1.12.1"}
         com.rpl/proxy-plus {:mvn/version "0.0.9"}}
  :aliases {:dev {:deps {nrepl/nrepl {:mvn/version "1.0.0"}
                         com.jetbrains.intellij.platform/ide-impl {:mvn/version "213.7172.48"

--- a/src/main/clojure/com/github/clojure_lsp/intellij/extension/documentation.clj
+++ b/src/main/clojure/com/github/clojure_lsp/intellij/extension/documentation.clj
@@ -9,9 +9,63 @@
   (:import
    [com.intellij.openapi.util.text StringUtil]
    [com.intellij.openapi.util.text HtmlBuilder]
-   [com.intellij.psi PsiDocumentManager PsiElement PsiFile]))
+   [com.intellij.psi PsiDocumentManager PsiElement PsiFile]
+   [com.intellij.openapi.fileTypes SyntaxHighlighterFactory]
+   [com.intellij.openapi.editor.colors EditorColorsManager]
+   [com.github.clojure_lsp.intellij ClojureLanguage]
+   [java.awt Color]))
 
 (set! *warn-on-reflection* true)
+
+(defn ^:private rgb-html-style [^Color color]
+  (str "rgb(" (.getRed color) ", " (.getGreen color) ", " (.getBlue color) ")"))
+
+(defn ^:private html-style [prop value]
+  (if (some? value)
+    (str prop ":" value ";") ""))
+
+(defn ^:private highlight-html-text
+  [^String text {:keys [foreground-color background-color font-type]}]
+  (let [color-style       (html-style "color" (when foreground-color
+                                                (rgb-html-style foreground-color)))
+        background-style  (html-style "background-color" (when background-color
+                                                           (rgb-html-style foreground-color)))
+        font-weight-style (html-style "font-weight" (case font-type
+                                                      :bold "bold"
+                                                      :bold-italic "bold"
+                                                      "normal"))
+        font-style        (html-style "font-style" (case font-type
+                                                     :italic "italic"
+                                                     :bold-italic "italic"
+                                                     "normal"))]
+    (str "<span style=\"" color-style background-style font-weight-style font-style "\">" text "</span>")))
+
+(defn ^:private highlight-html-code [^String code]
+  (let [highlighter  (SyntaxHighlighterFactory/getSyntaxHighlighter (ClojureLanguage/INSTANCE) nil nil)
+        lexer        (.getHighlightingLexer highlighter)
+        color-scheme (.getGlobalScheme (EditorColorsManager/getInstance))]
+    (loop [highlighted-code (str)]
+      (if (empty? highlighted-code)
+        (.start lexer code)
+        (.advance lexer))
+      (let [lexer-not-finished? (some? (.getTokenType lexer))]
+        (if lexer-not-finished?
+          (let [text             (.getTokenText lexer)
+                highlight        (first (.getTokenHighlights highlighter (.getTokenType lexer)))
+                highlight-attrs  (.getAttributes color-scheme highlight)
+                foreground-color (some-> highlight-attrs .getForegroundColor)
+                background-color (some-> highlight-attrs .getBackgroundColor)
+                font-type        (some-> highlight-attrs .getFontType (#(case (int %)
+                                                                         1 :bold
+                                                                         2 :italic
+                                                                         3 :bold-italic
+                                                                         nil)))]
+            (if (some some? [foreground-color background-color font-type])
+              (recur (str highlighted-code (highlight-html-text text {:foreground-color foreground-color
+                                                                      :background-color background-color
+                                                                      :font-type        font-type})))
+              (recur (str highlighted-code text))))
+          highlighted-code)))))
 
 (defn ^:private build-doc [^PsiElement element]
   (when-let [client (db/get-in (.getProject element) [:client])]
@@ -25,9 +79,14 @@
                                                               :position {:line (.line line-col)
                                                                          :character (.column line-col)}}])]
 
-        (when-let [raw-html (markdown/md-to-html-string (:value contents))]
+        (when-let [html (markdown/md-to-html-string (:value contents)
+                                                    :codeblock-no-escape? true
+                                                    :codeblock-callback (fn [code language]
+                                                                          (if (= language "clojure")
+                                                                            (highlight-html-code code)
+                                                                            code)))]
           (-> (HtmlBuilder.)
-              (.appendRaw raw-html)
+              (.appendRaw html)
               (.toString)))))))
 
 (defn -getCustomDocumentationElement

--- a/src/main/clojure/com/github/clojure_lsp/intellij/extension/documentation.clj
+++ b/src/main/clojure/com/github/clojure_lsp/intellij/extension/documentation.clj
@@ -22,7 +22,8 @@
 
 (defn ^:private html-style [prop value]
   (if (some? value)
-    (str prop ":" value ";") ""))
+    (str prop ":" value ";")
+    ""))
 
 (defn ^:private highlight-html-text
   [^String text {:keys [foreground-color background-color font-type]}]
@@ -44,11 +45,11 @@
   (let [highlighter  (SyntaxHighlighterFactory/getSyntaxHighlighter (ClojureLanguage/INSTANCE) nil nil)
         lexer        (.getHighlightingLexer highlighter)
         color-scheme (.getGlobalScheme (EditorColorsManager/getInstance))]
-    (loop [highlighted-code (str)]
+    (loop [highlighted-code ""]
       (if (empty? highlighted-code)
         (.start lexer code)
         (.advance lexer))
-      (let [lexer-not-finished? (some? (.getTokenType lexer))]
+      (let [lexer-not-finished? (.getTokenType lexer)]
         (if lexer-not-finished?
           (let [text             (.getTokenText lexer)
                 highlight        (first (.getTokenHighlights highlighter (.getTokenType lexer)))


### PR DESCRIPTION
Add syntax highlighting to codeblocks from Clojure documentation when viewed in IntelliJ's documentation window, improving readability and comprehension within the docs code. 

**Solves issue**: https://github.com/clojure-lsp/clojure-lsp-intellij/issues/38


**Key changes:**
- Upgraded `markdown-clj` to version `1.12.1`, which introduces the `:codeblock-callback` argument that enables the integration of a callback function to parse codeblocks from the documentation markdown, facilitating the addition of a highlight function
   - [markdown-clj documentation](https://github.com/yogthos/markdown-clj?tab=readme-ov-file#codeblock-callbacks) regarding codeblock callbacks
- Implemented the use of [SyntaxHighlighter](https://github.com/JetBrains/intellij-community/blob/master/platform/editor-ui-api/src/com/intellij/openapi/fileTypes/SyntaxHighlighter.java) and [Lexer](https://github.com/JetBrains/intellij-community/blob/master/platform/core-api/src/com/intellij/lexer/Lexer.java) to traverse through code tokens extracted from the codeblocks. Additionally, utilized [EditorColorsScheme](https://github.com/JetBrains/intellij-community/blob/master/platform/editor-ui-api/src/com/intellij/openapi/editor/colors/EditorColorsScheme.java) to obtain font color, background color, and font style attributes (**bold** and _italic_).
   - The code walking process is managed through `.start` and `.advance` methods from lexer, handling each code token such as parentheses `(` `)`, `defn`, variable names, etc.
- Based on the extracted token attributes, encapsulate each token within an HTML `<span>` element, applying inline styles to mimic the desired syntax highlighting effect translating the token attributes to CSS.

**How to test:**

Run plugin, install a theme or use a default one and try out.

**Preview:**

Using theme "One Dark Vivid Italic", before/after:

<img width="977" alt="before - a picture of clojure docs without highlighting of clojure.core/defn" src="https://github.com/clojure-lsp/clojure-lsp-intellij/assets/19965336/cb293bcb-3b96-4894-8182-84a9acc462d4">

<img width="971" alt="after - a picture of clojure docs with highlighting of clojure.core/defn" src="https://github.com/clojure-lsp/clojure-lsp-intellij/assets/19965336/6cb8954b-eb24-4ca3-a901-d5edc2630274">