### PR TITLE
Fix auto-closing quotes by including BAD_CHARACTER in QuoteHandler

### DIFF
--- a/src/main/kotlin/quote-handler.kt
+++ b/src/main/kotlin/quote-handler.kt
@@ -1,7 +1,7 @@
- package com.github.clojure_lsp.intellij.extension
+package com.github.clojure_lsp.intellij.extension
 
-  import com.intellij.codeInsight.editorActions.SimpleTokenSetQuoteHandler
-  import com.intellij.psi.TokenType
-  import com.github.clojure_lsp.intellij.ClojureTokens
+import com.intellij.codeInsight.editorActions.SimpleTokenSetQuoteHandler
+import com.intellij.psi.TokenType
+import com.github.clojure_lsp.intellij.ClojureTokens
 
-  class QuoteHandler : SimpleTokenSetQuoteHandler(ClojureTokens.STRINGS, TokenType.BAD_CHARACTER)
+class QuoteHandler : SimpleTokenSetQuoteHandler(ClojureTokens.STRINGS, TokenType.BAD_CHARACTER)

--- a/src/main/kotlin/quote-handler.kt
+++ b/src/main/kotlin/quote-handler.kt
@@ -1,6 +1,7 @@
-package com.github.clojure_lsp.intellij.extension
+ package com.github.clojure_lsp.intellij.extension
 
-import com.intellij.codeInsight.editorActions.SimpleTokenSetQuoteHandler
-import com.github.clojure_lsp.intellij.ClojureTokens
+  import com.intellij.codeInsight.editorActions.SimpleTokenSetQuoteHandler
+  import com.intellij.psi.TokenType
+  import com.github.clojure_lsp.intellij.ClojureTokens
 
-class QuoteHandler : SimpleTokenSetQuoteHandler(ClojureTokens.STRINGS)
+  class QuoteHandler : SimpleTokenSetQuoteHandler(ClojureTokens.STRINGS, TokenType.BAD_CHARACTER)


### PR DESCRIPTION
Problem                                                                                                                                                                                                                                                                                                       When the clojure-lsp-intellij plugin is enabled, auto-closing of double quotes (") stops working in IntelliJ IDEA. Typing " should produce "" with     the cursor between them, but only a single " appears.

  Bracket auto-closing ((), {}, []) works fine.

  Root Cause

  The Clojure lexer requires both opening and closing quotes to recognize a STRING token (C_STRING). When typing a single ", the lexer produces
  BAD_CHARACTER instead.

  QuoteHandler only knew about C_STRING tokens, so isOpeningQuote() returned false for the first " — preventing IntelliJ from inserting the closing
  quote.

  Fix

  Added TokenType.BAD_CHARACTER to the SimpleTokenSetQuoteHandler constructor. This is a well-known pattern used by other IntelliJ language plugins
  (JSON, BNF, etc.).