### PR TITLE
Fix new namespace creation placing files under absolute filesystem path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix new namespace creation incorrectly creating files under the absolute host filesystem path. #83
+
 ## 3.5.2
 
 - Fix `QuoteHandler` compile error by merging `BAD_CHARACTER` into the quote-handler `TokenSet`.

--- a/src/main/clojure/com/github/clojure_lsp/intellij/extension/new_file.clj
+++ b/src/main/clojure/com/github/clojure_lsp/intellij/extension/new_file.clj
@@ -1,6 +1,5 @@
 (ns com.github.clojure-lsp.intellij.extension.new-file
   (:require
-   [clojure.java.io :as io]
    [clojure.string :as string]
    [com.github.clojure-lsp.intellij.client :as lsp-client]
    [com.rpl.proxy-plus :refer [proxy+]])
@@ -8,24 +7,61 @@
    [com.github.clojure_lsp.intellij Icons]
    [com.intellij.ide.actions CreateFileFromTemplateAction CreateFileFromTemplateDialog$Builder]
    [com.intellij.ide.fileTemplates FileTemplate]
-   [com.intellij.psi PsiDirectory]))
+   [com.intellij.psi PsiDirectory]
+   [java.io File]
+   [java.nio.file Path Paths]))
 
 (set! *warn-on-reflection* true)
 
+(defn ^:private ->path ^Path [^String s]
+  (when (and s (not (string/blank? s)))
+    (let [cleaned (cond-> s
+                    (string/starts-with? s "file://") (subs 7))]
+      (try
+        (-> (Paths/get cleaned (into-array String []))
+            .toAbsolutePath
+            .normalize)
+        (catch Exception _ nil)))))
+
 (defn ^:private filename->source-path [filename project]
-  (let [source-paths (get-in (lsp-client/server-info project) [:final-settings "source-paths"])]
-    (first (filter #(string/starts-with? filename %) source-paths))))
+  (let [dir-path (->path filename)
+        source-paths (get-in (lsp-client/server-info project) [:final-settings "source-paths"])]
+    (when dir-path
+      (some (fn [sp]
+              (when-let [spath (->path sp)]
+                (when (.startsWith dir-path spath)
+                  spath)))
+            source-paths))))
 
 (defn ^:private dir->partial-namespace
   [filename project]
-  (when-let [current-source-path (filename->source-path filename project)]
-    (some-> filename
-            (string/replace-first (re-pattern current-source-path) "")
-            (string/replace (System/getProperty "file.separator") ".")
-            (string/replace #"_" "-")
-            not-empty
-            (subs 1)
-            (str "."))))
+  (when-let [source-path (filename->source-path filename project)]
+    (when-let [dir-path (->path filename)]
+      (let [rel-str (str (.relativize ^Path source-path ^Path dir-path))]
+        (when-not (string/blank? rel-str)
+          (-> rel-str
+              (string/replace File/separator ".")
+              (string/replace "_" "-")
+              (str ".")))))))
+
+(defn ^:private ns->rel-path
+  "Возвращает путь нового файла ОТНОСИТЕЛЬНО dir, как требует createFileFromTemplate."
+  [project ^String ns ^PsiDirectory dir]
+  (let [separator    File/separator
+        dir-filename (.getPath (.getVirtualFile dir))
+        source-path  (filename->source-path dir-filename project)
+        ns-path      (-> ns
+                         (string/replace "." separator)
+                         (string/replace "-" "_"))]
+    (if-let [sp source-path]
+      (if-let [dir-path (->path dir-filename)]
+        (let [rel-dir (str (.relativize ^Path sp ^Path dir-path))
+              prefix  (if (string/blank? rel-dir) "" (str rel-dir separator))]
+          (if (and (seq prefix) (string/starts-with? ns-path prefix))
+            (subs ns-path (count prefix))
+            ns-path))
+        ns-path)
+      ns-path)))
 
 (defn ^:private dialog [project ^PsiDirectory dir ^CreateFileFromTemplateDialog$Builder builder]
   (let [filename (.getPath (.getVirtualFile dir))
@@ -40,15 +76,7 @@
 
 (defn ^:private create-file-from-template
   [project ^String ns ^FileTemplate template ^PsiDirectory dir]
-  (let [dir-filename (.getPath (.getVirtualFile dir))
-        separator (System/getProperty "file.separator")
-        source-path (filename->source-path dir-filename project)
-        ns-path (-> ns
-                    (string/replace "." separator)
-                    (string/replace "-" "_"))
-        new-name (string/replace-first (.getCanonicalPath (io/file source-path ns-path))
-                                       (str dir-filename separator)
-                                       "")]
+  (let [new-name (ns->rel-path project ns dir)]
     (CreateFileFromTemplateAction/createFileFromTemplate new-name template dir nil true)))
 
 (defn ->ClojureNewFileAction [project]

--- a/src/main/clojure/com/github/clojure_lsp/intellij/extension/new_file.clj
+++ b/src/main/clojure/com/github/clojure_lsp/intellij/extension/new_file.clj
@@ -45,7 +45,7 @@
               (str ".")))))))
 
 (defn ^:private ns->rel-path
-  "Возвращает путь нового файла ОТНОСИТЕЛЬНО dir, как требует createFileFromTemplate."
+  "Returns the new file path RELATIVE to dir, as createFileFromTemplate requires."
   [project ^String ns ^PsiDirectory dir]
   (let [separator    File/separator
         dir-filename (.getPath (.getVirtualFile dir))


### PR DESCRIPTION
## Bug

  Creating a new Clojure namespace via Project view → New → Clojure namespace
  sometimes creates the file under an absolute host path inside the target
  directory.

  Example: clicking "New namespace" on `src/project_name/` and entering
  `test` creates the file at:

  src/project_name/home/username/code/clojure_proj/project_name/src/test.clj

  instead of the expected:

  src/project_name/test.clj

  ## Root cause

  `create-file-from-template` in `new_file.clj` built an absolute canonical
  path via `io/file` + `getCanonicalPath` and then tried to strip the
  directory prefix with `string/replace-first`.

  This is fragile:
  - `clojure-lsp` may return `source-paths` as `file://` URIs
  - `VirtualFile.getPath` may use a different separator than `getCanonicalPath`
  - `source-paths` may be project-relative strings

  When the prefix does not match, `replace-first` silently returns the full
  absolute path, which IntelliJ then interprets as a path relative to the
  target directory and recreates the whole host path tree inside it.

  `dir->partial-namespace` had the same class of bug — if the prefix didn't
  match it returned `(subs filename 1)` which produced nonsense namespaces
  like `home.username.code.proj...`.

  ## Fix

  Rewrite path math using `java.nio.file.Path`:

  - Normalize URIs (`file://`) and separators via a helper `->path`
  - Use `Path.startsWith` for source-path detection (real segment-wise
    comparison instead of substring matching)
  - Use `Path.relativize` to compute
    - the directory's path relative to the source root (for the default
      namespace prefix in the dialog), and
    - the namespace path relative to the directory (for the `new-name`
      passed to `CreateFileFromTemplateAction/createFileFromTemplate`)

  No more string-prefix matching on raw paths.

  ## Testing

  Didn't rebuild locally (no toolchain on the machine I made the fix on).
  Relying on CI + reviewer verification. Happy to iterate on review.
