### PR TITLE
fix: guard against nil keyboard-shortcut in register-action!

### DIFF
--- a/src/main/clojure/com/github/clojure_lsp/intellij/extension/register_actions_startup.clj
+++ b/src/main/clojure/com/github/clojure_lsp/intellij/extension/register_actions_startup.clj
@@ -127,12 +127,12 @@
     (doseq [{:keys [name text description use-shortcut-of keyboard-shortcut]} clojure-lsp-commands]
           (apply action/register-action!
                   (cond-> [:id (str "ClojureLSP." (csk/->PascalCase name))
-                                   :title text
-                                                    :description description
-                                                                     :icon Icons/CLOJURE
-                                                                                      :use-shortcut-of use-shortcut-of
-                                                                                                       :on-performed (partial on-action-performed name text)]
-                                                                                                                 keyboard-shortcut (conj :keyboard-shortcut keyboard-shortcut)))))
+                           :title text
+                           :description description
+                           :icon Icons/CLOJURE
+                           :use-shortcut-of use-shortcut-of
+                           :on-performed (partial on-action-performed name text)]
+                 keyboard-shortcut (conj :keyboard-shortcut keyboard-shortcut)))))
     (register-command! :id "code-lens-references"
                        :on-performed #'code-lens-references-performed)
     (action/register-group! :id "ClojureLSP.Refactors"

--- a/src/main/clojure/com/github/clojure_lsp/intellij/extension/register_actions_startup.clj
+++ b/src/main/clojure/com/github/clojure_lsp/intellij/extension/register_actions_startup.clj
@@ -20,7 +20,7 @@
     CommonDataKeys]
    [com.intellij.openapi.editor Editor]
    [com.intellij.openapi.project Project]
-   [com.intellij.openapi.startup ProjectActivity]
+   [com.intellij.openapi.startup ProjectActivity
    [com.redhat.devtools.lsp4ij LanguageServerManager]
    [com.redhat.devtools.lsp4ij.commands LSPCommand LSPCommandAction]
    [com.redhat.devtools.lsp4ij.usages LSPUsageType LSPUsagesManager LocationData]
@@ -125,13 +125,14 @@
                             :children [{:type :add-to-group :group-id "NewGroup" :anchor :first}
                                        {:type :reference :ref "ClojureLSP.NewClojureFile"}])
     (doseq [{:keys [name text description use-shortcut-of keyboard-shortcut]} clojure-lsp-commands]
-      (action/register-action! :id (str "ClojureLSP." (csk/->PascalCase name))
-                               :title text
-                               :description description
-                               :icon Icons/CLOJURE
-                               :keyboard-shortcut keyboard-shortcut
-                               :use-shortcut-of use-shortcut-of
-                               :on-performed (partial on-action-performed name text)))
+          (apply action/register-action!
+                  (cond-> [:id (str "ClojureLSP." (csk/->PascalCase name))
+                                   :title text
+                                                    :description description
+                                                                     :icon Icons/CLOJURE
+                                                                                      :use-shortcut-of use-shortcut-of
+                                                                                                       :on-performed (partial on-action-performed name text)]
+                                                                                                                 keyboard-shortcut (conj :keyboard-shortcut keyboard-shortcut)))))
     (register-command! :id "code-lens-references"
                        :on-performed #'code-lens-references-performed)
     (action/register-group! :id "ClojureLSP.Refactors"

--- a/src/main/clojure/com/github/clojure_lsp/intellij/extension/register_actions_startup.clj
+++ b/src/main/clojure/com/github/clojure_lsp/intellij/extension/register_actions_startup.clj
@@ -20,7 +20,7 @@
     CommonDataKeys]
    [com.intellij.openapi.editor Editor]
    [com.intellij.openapi.project Project]
-   [com.intellij.openapi.startup ProjectActivity
+   [com.intellij.openapi.startup ProjectActivity]
    [com.redhat.devtools.lsp4ij LanguageServerManager]
    [com.redhat.devtools.lsp4ij.commands LSPCommand LSPCommandAction]
    [com.redhat.devtools.lsp4ij.usages LSPUsageType LSPUsagesManager LocationData]
@@ -125,14 +125,14 @@
                             :children [{:type :add-to-group :group-id "NewGroup" :anchor :first}
                                        {:type :reference :ref "ClojureLSP.NewClojureFile"}])
     (doseq [{:keys [name text description use-shortcut-of keyboard-shortcut]} clojure-lsp-commands]
-          (apply action/register-action!
-                  (cond-> [:id (str "ClojureLSP." (csk/->PascalCase name))
-                           :title text
-                           :description description
-                           :icon Icons/CLOJURE
-                           :use-shortcut-of use-shortcut-of
-                           :on-performed (partial on-action-performed name text)]
-                 keyboard-shortcut (conj :keyboard-shortcut keyboard-shortcut)))))
+      (apply action/register-action!
+             (cond-> [:id (str "ClojureLSP." (csk/->PascalCase name))
+                      :title text
+                      :description description
+                      :icon Icons/CLOJURE
+                      :use-shortcut-of use-shortcut-of
+                      :on-performed (partial on-action-performed name text)]
+               keyboard-shortcut (into [:keyboard-shortcut keyboard-shortcut]))))
     (register-command! :id "code-lens-references"
                        :on-performed #'code-lens-references-performed)
     (action/register-group! :id "ClojureLSP.Refactors"


### PR DESCRIPTION
## Problem

On IntelliJ startup, the plugin throws a `PluginException` wrapping a `NullPointerException` because the `doseq` loop in `RegisterActionsStartup` iterates over `clojure-lsp-commands` and passes `:keyboard-shortcut keyboard-shortcut` unconditionally to `action/register-action!`. Commands that don't define a keyboard shortcut (most of them) have `nil` here, which violates IntelliJ's `@NotNull` contract on `KeymapImpl.addShortcut`.

Fixes #84

## Solution

Wrap the call with `apply` and use `cond->` to only include `:keyboard-shortcut` in the args vector when it is non-nil:

```clojure
(apply action/register-action!
  (cond-> [:id ... :title text ...]
    keyboard-shortcut (conj :keyboard-shortcut keyboard-shortcut)))
```

This way commands without a shortcut are still registered correctly, and `KeymapImpl.addShortcut` is never called with a `nil` shortcut.